### PR TITLE
Support prependable encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A collection of useful algorithms written in Rust. Currently contains:
 
 - [`geo_filters`](crates/geo_filters): probabilistic data structures that solve the [Distinct Count Problem](https://en.wikipedia.org/wiki/Count-distinct_problem) using geometric filters.
+- [`bpe`](crates/bpe): fast, correct, and novel algorithms for the [Byte Pair Encoding Algorithm](https://en.wikipedia.org/wiki/Large_language_model#BPE) which are particularly useful for chunking of documents.
 
 ## Background
 

--- a/crates/bpe/Cargo.toml
+++ b/crates/bpe/Cargo.toml
@@ -9,7 +9,7 @@ bench = false
 
 [dependencies]
 #daachorse = "1"
-daachorse = { git = "https://github.com/aneubeck/daachorse.git", rev = "22f471532a25d90a320eae0902c759db2b8fe962" }
+daachorse = { git = "https://github.com/aneubeck/daachorse.git", rev = "ac44a471a7be5a139535173073b8f1cd2e33bcbd" }
 fnv = "1.0"
 itertools = "0.12"
 once_cell = "1"

--- a/crates/bpe/src/appendable_encoder.rs
+++ b/crates/bpe/src/appendable_encoder.rs
@@ -2,7 +2,7 @@ use daachorse::bytewise::iter::OverlappingStepper;
 
 use crate::byte_pair_encoding::BytePairEncoding;
 
-/// Encoder which keeps track of the encoding length.
+/// Encoder which keeps track of the encoding length while appending characters.
 pub struct AppendableEncoder<'a> {
     bpe: &'a BytePairEncoding,
     stepper: OverlappingStepper<'a, u32>,

--- a/crates/bpe/src/appendable_encoder.rs
+++ b/crates/bpe/src/appendable_encoder.rs
@@ -1,26 +1,22 @@
-use daachorse::bytewise::iter::OverlappingStepper;
-
 use crate::byte_pair_encoding::BytePairEncoding;
+
+struct State {
+    state: u32,
+    last_token: u32,
+    count: u32,
+}
 
 /// Encoder which keeps track of the encoding length while appending characters.
 pub struct AppendableEncoder<'a> {
     bpe: &'a BytePairEncoding,
-    stepper: OverlappingStepper<'a, u32>,
-    // TODO: If we only want to answer the length of the input text, then we could
-    // replace these vectors with some fixed size arrays. Essentially we can only
-    // go back up to the length of the longest token. This way can save some memory
-    // and reallocations.
-    last_token: Vec<u32>,
-    counts: Vec<u32>,
+    states: Vec<State>,
 }
 
 impl<'a> AppendableEncoder<'a> {
     pub fn new(bpe: &'a BytePairEncoding) -> Self {
         Self {
             bpe,
-            stepper: bpe.overlapping_searcher.overlapping_stepper(),
-            last_token: vec![],
-            counts: vec![],
+            states: vec![],
         }
     }
 
@@ -31,24 +27,43 @@ impl<'a> AppendableEncoder<'a> {
         }
     }
 
+    pub fn truncate(&mut self, len: usize) {
+        self.states.truncate(len);
+    }
+
     /// Appends a byte to the input string which should be tokenized.
     /// The operation is amortized O(1) (due to vector resizing).
     pub fn push(&mut self, c: u8) {
-        self.stepper.consume(c);
-        while let Some(m) = self.stepper.next() {
+        let (state, iter) = self.bpe.overlapping_searcher.consume(
+            self.states
+                .last()
+                .map(|s| s.state)
+                .unwrap_or_else(|| self.bpe.overlapping_searcher.start_state()),
+            self.states.len() + 1,
+            c,
+        );
+        for m in iter {
             let new_token = m.value();
             let new_range = m.start()..m.end();
-            assert_eq!(new_range.end, self.last_token.len() + 1);
+            assert_eq!(new_range.end, self.states.len() + 1);
             if new_range.start == 0 {
-                self.last_token.push(new_token);
-                self.counts.push(1);
+                self.states.push(State {
+                    state,
+                    last_token: new_token,
+                    count: 1,
+                });
                 break;
             } else {
-                let prev_token = unsafe { *self.last_token.get_unchecked(new_range.start - 1) };
+                let prev_token =
+                    unsafe { self.states.get_unchecked(new_range.start - 1).last_token };
                 if self.bpe.is_valid_token_pair(prev_token, new_token) {
-                    self.last_token.push(new_token);
-                    let prev_count = unsafe { *self.counts.get_unchecked(new_range.start - 1) };
-                    self.counts.push(prev_count + 1);
+                    let prev_count =
+                        unsafe { self.states.get_unchecked(new_range.start - 1).count };
+                    self.states.push(State {
+                        state,
+                        last_token: new_token,
+                        count: prev_count + 1,
+                    });
                     break;
                 }
             }
@@ -57,13 +72,17 @@ impl<'a> AppendableEncoder<'a> {
 
     /// Returns the number of tokens required to tokenize the input text.
     /// This operation is O(1) and can be called at any point in time.
+    pub fn token_count(&self) -> usize {
+        self.states.last().map(|s| s.count).unwrap_or(0) as usize
+    }
+
     pub fn len(&self) -> usize {
-        self.counts.last().copied().unwrap_or(0) as usize
+        self.states.len()
     }
 
     /// Returns true if the structure represents the empty string.
     pub fn is_empty(&self) -> bool {
-        self.counts.is_empty()
+        self.states.is_empty()
     }
 }
 
@@ -79,7 +98,7 @@ mod tests {
         let mut enc = AppendableEncoder::new(bpe);
         let input_string = create_test_bytes(bpe, 100);
         for (i, c) in input_string.iter().enumerate() {
-            assert_eq!(enc.len(), bpe.count(&input_string[0..i]));
+            assert_eq!(enc.token_count(), bpe.count(&input_string[0..i]));
             enc.push(*c);
         }
     }

--- a/crates/bpe/src/lib.rs
+++ b/crates/bpe/src/lib.rs
@@ -3,3 +3,4 @@ pub mod backtrack_encoder;
 mod bitfield;
 pub mod byte_pair_encoding;
 pub mod interval_encoding;
+pub mod prependable_encoder;

--- a/crates/bpe/src/prependable_encoder.rs
+++ b/crates/bpe/src/prependable_encoder.rs
@@ -1,0 +1,85 @@
+use daachorse::bytewise::iter::OverlappingStepper;
+
+use crate::byte_pair_encoding::BytePairEncoding;
+
+/// Encoder which keeps track of the encoding length while prepending characters.
+/// 
+/// TODO: Implement a way to checkpoint the state of the encoder.
+/// This requires changing the aho corasick API to just return the current state.
+pub struct PrependableEncoder<'a> {
+    bpe: &'a BytePairEncoding,
+    stepper: OverlappingStepper<'a, u32>,
+    prev_token: Vec<u32>,
+    counts: Vec<u32>,
+}
+
+impl<'a> PrependableEncoder<'a> {
+    pub fn new(bpe: &'a BytePairEncoding) -> Self {
+        Self {
+            bpe,
+            stepper: bpe.overlapping_searcher_rev.overlapping_stepper(),
+            prev_token: vec![],
+            counts: vec![],
+        }
+    }
+
+    /// Prepends multiple bytes to the input string.
+    pub fn extend(&mut self, iter: impl Iterator<Item = u8>) {
+        for c in iter {
+            self.push(c);
+        }
+    }
+
+    /// Prepends a byte to the input string which should be tokenized.
+    /// The operation is amortized O(1) (due to vector resizing).
+    pub fn push(&mut self, c: u8) {
+        self.stepper.consume(c);
+        while let Some(m) = self.stepper.next() {
+            let new_token = m.value();
+            let new_range = m.start()..m.end();
+            assert_eq!(new_range.end, self.prev_token.len() + 1);
+            if new_range.start == 0 {
+                self.prev_token.push(new_token);
+                self.counts.push(1);
+                break;
+            } else {
+                let next_token = unsafe { *self.prev_token.get_unchecked(new_range.start - 1) };
+                if self.bpe.is_valid_token_pair(new_token, next_token) {
+                    self.prev_token.push(new_token);
+                    let prev_count = unsafe { *self.counts.get_unchecked(new_range.start - 1) };
+                    self.counts.push(prev_count + 1);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Returns the number of tokens required to tokenize the input text.
+    /// This operation is O(1) and can be called at any point in time.
+    pub fn len(&self) -> usize {
+        self.counts.last().copied().unwrap_or(0) as usize
+    }
+
+    /// Returns true if the structure represents the empty string.
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::byte_pair_encoding::{create_test_bytes, BytePairEncoding};
+
+    use super::PrependableEncoder;
+
+    #[test]
+    fn test_prependable_encoder() {
+        let bpe = BytePairEncoding::cl100k();
+        let mut enc = PrependableEncoder::new(bpe);
+        let input_string = create_test_bytes(bpe, 100);
+        for (i, c) in input_string.iter().enumerate().rev() {
+            enc.push(*c);
+            assert_eq!(enc.len(), bpe.count(&input_string[i..]));
+        }
+    }
+}

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -518,6 +518,9 @@ mod tests {
             let masked_a = masked(&a, mask, mask_size);
             let masked_b = masked(&b, mask, mask_size);
             let masked_expected = masked(&expected, mask, mask_size);
+            // FIXME: test failed once with:
+            // left: ~12.37563 (msb: [390, 334, 263, 242, 222, 215, 164, 148, 100, 97, 66, 36], |lsb|: 36)
+            // right: ~12.37563 (msb: [390, 334, 263, 242, 222, 215, 164, 148, 100, 97, 66, 36], |lsb|: 0)
             assert_eq!(masked_expected, xor(&masked_a, &masked_b));
         }
     }


### PR DESCRIPTION
In semantic chunking, the tail of the nested structure must be processed in reverse order.
This PR introduces a new PrependableEncoder which supports exactly this reverse processing.
Additionally, characters can now be efficiently removed from the encoder again, such that semantic chunking can implement checkpointing on top.