### PR TITLE
Fix incorrect use of usize for 32 bit systems

### DIFF
--- a/crates/string-offsets/src/lib.rs
+++ b/crates/string-offsets/src/lib.rs
@@ -385,8 +385,8 @@ fn new_converter(content: &[u8]) -> StringOffsets {
 /// Returns 0 if the byte is not a valid first byte of a UTF-8 char.
 fn utf8_width(c: u8) -> usize {
     // Every nibble represents the utf8 length given the first 4 bits of a utf8 encoded byte.
-    const UTF8_WIDTH: usize = 0x4322_0000_1111_1111;
-    (UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf
+    const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111;
+    ((UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf).try_into().unwrap()
 }
 
 fn utf8_to_utf16_width(content: &[u8]) -> usize {

--- a/crates/string-offsets/src/lib.rs
+++ b/crates/string-offsets/src/lib.rs
@@ -385,7 +385,7 @@ fn new_converter(content: &[u8]) -> StringOffsets {
 /// Returns 0 if the byte is not a valid first byte of a UTF-8 char.
 fn utf8_width(c: u8) -> usize {
     // Every nibble represents the utf8 length given the first 4 bits of a utf8 encoded byte.
-    const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111;
+    const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111 ;
     ((UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf) as usize
 }
 

--- a/crates/string-offsets/src/lib.rs
+++ b/crates/string-offsets/src/lib.rs
@@ -385,7 +385,7 @@ fn new_converter(content: &[u8]) -> StringOffsets {
 /// Returns 0 if the byte is not a valid first byte of a UTF-8 char.
 fn utf8_width(c: u8) -> usize {
     // Every nibble represents the utf8 length given the first 4 bits of a utf8 encoded byte.
-    const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111 ;
+    const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111;
     ((UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf) as usize
 }
 

--- a/crates/string-offsets/src/lib.rs
+++ b/crates/string-offsets/src/lib.rs
@@ -386,7 +386,7 @@ fn new_converter(content: &[u8]) -> StringOffsets {
 fn utf8_width(c: u8) -> usize {
     // Every nibble represents the utf8 length given the first 4 bits of a utf8 encoded byte.
     const UTF8_WIDTH: u64 = 0x4322_0000_1111_1111;
-    ((UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf).try_into().unwrap()
+    ((UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf) as usize
 }
 
 fn utf8_to_utf16_width(content: &[u8]) -> usize {


### PR DESCRIPTION
When compiling to wasm, I noticed this library would not produce the correct outputs. After much frustration, I finally tracked this issue down to the line:

```rust
    const UTF8_WIDTH: usize = 0x4322_0000_1111_1111;
    (UTF8_WIDTH >> ((c >> 4) * 4)) & 0xf
```

This works fine on 64 bit systems, but on 32 bit systems, the `usize` type is 32 bits so the literal gets truncated. If you are compiling this library directly, you get an error about this but apparently you don't if you're using it as a dependency

Just a rust noob so let me know if there's a better fix