### PR TITLE
actions: Update events that trigger CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
+    tags: [ *-v*.*.* ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [ main ]
-    tags: [ *-v*.*.* ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
* Add `workflow_dispatch` so that CI can be manually triggered.
* Restrict `push` triggers to main and version tags.
* Add `pull_request` so that CI runs properly on PRs from external contributors. 