### PR TITLE
Deterministic RNG test harness and address bug in `BitVec`

### DIFF
--- a/crates/geo_filters/src/config.rs
+++ b/crates/geo_filters/src/config.rs
@@ -353,29 +353,30 @@ pub(crate) fn take_ref<I: Iterator>(iter: &mut I, n: usize) -> impl Iterator<Ite
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use rand::{RngCore, SeedableRng};
+    use rand::RngCore;
 
-    use crate::{Count, Method};
+    use crate::{test_rng::prng_test_harness, Count, Method};
 
     /// Runs estimation trials and returns the average precision and variance.
     pub(crate) fn test_estimate<M: Method, C: Count<M>>(f: impl Fn() -> C) -> (f32, f32) {
-        let mut rnd = rand::rngs::StdRng::from_os_rng();
-        let cnt = 10000usize;
-        let mut avg_precision = 0.0;
-        let mut avg_var = 0.0;
-        let trials = 500;
-        for _ in 0..trials {
-            let mut m = f();
-            // Insert cnt many random items.
-            for _ in 0..cnt {
-                m.push_hash(rnd.next_u64());
+        prng_test_harness(|rnd| {
+            let cnt = 10000usize;
+            let mut avg_precision = 0.0;
+            let mut avg_var = 0.0;
+            let trials = 500;
+            for _ in 0..trials {
+                let mut m = f();
+                // Insert cnt many random items.
+                for _ in 0..cnt {
+                    m.push_hash(rnd.next_u64());
+                }
+                // Compute the relative error between estimate and actually inserted items.
+                let high_precision = m.size() / cnt as f32 - 1.0;
+                // Take the average over trials many attempts.
+                avg_precision += high_precision / trials as f32;
+                avg_var += high_precision.powf(2.0) / trials as f32;
             }
-            // Compute the relative error between estimate and actually inserted items.
-            let high_precision = m.size() / cnt as f32 - 1.0;
-            // Take the average over trials many attempts.
-            avg_precision += high_precision / trials as f32;
-            avg_var += high_precision.powf(2.0) / trials as f32;
-        }
-        (avg_precision, avg_var)
+            (avg_precision, avg_var)
+        })
     }
 }

--- a/crates/geo_filters/src/diff_count/bitvec.rs
+++ b/crates/geo_filters/src/diff_count/bitvec.rs
@@ -101,8 +101,6 @@ impl BitVec<'_> {
         assert!(index < self.num_bits);
         let (block_idx, bit_idx) = index.into_index_and_bit();
         self.blocks.to_mut()[block_idx] ^= bit_idx.into_block();
-
-        if self.blocks.to_mut()[block_idx] & bit_idx.into_block() == 0 {}
     }
 
     /// Returns an iterator over all blocks in reverse order.

--- a/crates/geo_filters/src/diff_count/bitvec.rs
+++ b/crates/geo_filters/src/diff_count/bitvec.rs
@@ -12,11 +12,19 @@ use crate::config::BITS_PER_BLOCK;
 /// bit consumes 1 byte). It only implements the minimum number of operations that we need for our
 /// GeoDiffCount implementation. In particular it supports xor-ing of two bit vectors and
 /// iterating through one bits.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug)]
 pub(crate) struct BitVec<'a> {
     num_bits: usize,
     blocks: Cow<'a, [u64]>,
 }
+
+impl PartialEq for BitVec<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bit_chunks().eq(other.bit_chunks())
+    }
+}
+
+impl Eq for BitVec<'_> {}
 
 impl Ord for BitVec<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -93,6 +101,8 @@ impl BitVec<'_> {
         assert!(index < self.num_bits);
         let (block_idx, bit_idx) = index.into_index_and_bit();
         self.blocks.to_mut()[block_idx] ^= bit_idx.into_block();
+
+        if self.blocks.to_mut()[block_idx] & bit_idx.into_block() == 0 {}
     }
 
     /// Returns an iterator over all blocks in reverse order.

--- a/crates/geo_filters/src/lib.rs
+++ b/crates/geo_filters/src/lib.rs
@@ -13,6 +13,8 @@ pub mod diff_count;
 pub mod distinct_count;
 #[cfg(feature = "evaluation")]
 pub mod evaluation;
+#[cfg(test)]
+mod test_rng;
 
 use std::hash::Hash;
 

--- a/crates/geo_filters/src/test_rng.rs
+++ b/crates/geo_filters/src/test_rng.rs
@@ -1,4 +1,4 @@
-use std::panic::{catch_unwind, resume_unwind, UnwindSafe};
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 
 use rand::{rngs::StdRng, SeedableRng as _};
 
@@ -6,19 +6,20 @@ use rand::{rngs::StdRng, SeedableRng as _};
 /// degree of randomization. If the test panics the harness will print the
 /// seed used for that run. You can then pass in this seed using the `TEST_SEED`
 /// environment variable when running your tests.
-pub fn prng_test_harness<F>(test_fn: F)
+pub fn prng_test_harness<F, T>(test_fn: F) -> T
 where
-    F: Fn(StdRng) -> () + UnwindSafe,
+    F: Fn(&mut StdRng) -> T,
 {
     let seed = std::env::var("TEST_SEED")
         .map(|s| s.parse::<u64>().expect("Parse TEST_SEED to u64"))
         .unwrap_or_else(|_| rand::random());
-    let rng = StdRng::seed_from_u64(seed);
-    let maybe_panic = catch_unwind(move || {
-        test_fn(rng);
-    });
-    if let Err(panic_info) = maybe_panic {
-        eprintln!("Test failed! Reproduce with: TEST_SEED={}", seed);
-        resume_unwind(panic_info);
+    let mut rng = StdRng::seed_from_u64(seed);
+    let maybe_panic = catch_unwind(AssertUnwindSafe(|| test_fn(&mut rng)));
+    match maybe_panic {
+        Ok(t) => t,
+        Err(panic_info) => {
+            eprintln!("Test failed! Reproduce with: TEST_SEED={}", seed);
+            resume_unwind(panic_info);
+        }
     }
 }

--- a/crates/geo_filters/src/test_rng.rs
+++ b/crates/geo_filters/src/test_rng.rs
@@ -1,0 +1,24 @@
+use std::panic::{catch_unwind, resume_unwind, UnwindSafe};
+
+use rand::{rngs::StdRng, SeedableRng as _};
+
+/// Provides a seeded random number generator to tests which require some
+/// degree of randomization. If the test panics the harness will print the
+/// seed used for that run. You can then pass in this seed using the `TEST_SEED`
+/// environment variable when running your tests.
+pub fn prng_test_harness<F>(test_fn: F)
+where
+    F: Fn(StdRng) -> () + UnwindSafe,
+{
+    let seed = std::env::var("TEST_SEED")
+        .map(|s| s.parse::<u64>().expect("Parse TEST_SEED to u64"))
+        .unwrap_or_else(|_| rand::random());
+    let rng = StdRng::seed_from_u64(seed);
+    let maybe_panic = catch_unwind(move || {
+        test_fn(rng);
+    });
+    if let Err(panic_info) = maybe_panic {
+        eprintln!("Test failed! Reproduce with: TEST_SEED={}", seed);
+        resume_unwind(panic_info);
+    }
+}


### PR DESCRIPTION
## Why?

There have been random test failures caused by some invariants not being maintained in the LSB `BitVec`. This presents two problems.

1. There seem to be bugs in our code, at least according to the tests.
2. The tests are random and thus failures are hard to reproduce

## How?

To address this I've done two things.

Firstly, I implement a test harness for running tests which require a random number generator (RNG). This harness accepts a lambda function which has a single argument, a RNG. Under normal conditions the RNG is seeded randomly as a typical thread local RNG. The difference occurs when you get a test failure, at which point the harness captures the panic and prints out the RNG seed. You can then rerun your tests with `TEST_SEED=...` set as an environment variable in order to start the test with the seed that failed. This allows developers to rerun the test and see the failure immediately, a generally useful thing to be able to do :)

E.g. you run some tests with `cargo test` and get the following error message from a flakey test:

```
---- diff_count::tests::test_xor_plus_mask stdout ----

thread 'diff_count::tests::test_xor_plus_mask' panicked at crates/geo_filters/src/diff_count.rs:535:21:
assertion `left == right` failed
  left: ~12.37563 (msb: [419, 328, 284, 251, 237, 180, 148, 117, 108, 67, 60, 26], |lsb|: 26)
 right: ~12.37563 (msb: [419, 328, 284, 251, 237, 180, 148, 117, 108, 67, 60, 26], |lsb|: 0)
Test failed! Reproduce with: TEST_SEED=16501082297235867130
```

You can then re-run with `TEST_SEED=16501082297235867130 cargo test` and the test will fail reliably.

I rewrote all our `tests` to use this since it's good to be able to reproduce issues. I did not roll it out to the `evaluation` code.

Secondly, I fix issue where `BitVec` was required to be structurally identical rather than just semantically equivalent to pass equality checks. Specifically, an empty `BitVec` with no blocks is semantically the same as a `BitVec` with `>=1` block where all the bits are zeros, but the `PartialEq` function didn't consider them the same.

This caused issues when bits in the LSB were toggled directly. An item is pushed, hashed and assigned a bucket. If the bucket is in the MSB range then the LSB is updated and potentially resized. If the bucket is in the LSB range the bit is toggled but the bucket is _not_ resized. This is because we expect most items to toggle bits in the LSB range so not resizing the buffer every time this happen saves us on some performance.

This issue would only happen relatively rarely, given that it needed the last item inserted to toggle the last bit in the LSB before the equality check is performed. Usually there is more than 1 bit in the LSB set before the final item is inserted.

I addressed this issue by changing how `PartialEq::eq` is implemented to check that the set bits are equivalent using the existing `bit_chunks` iterator.

I think it in the serialization code (PR not yet merged) it would make sense to resize the LSB before serialization to prevent writing empty bytes to disk.

## Alternative approaches

For the deterministic RNG I could have used something like `proptest`, but it felt like too big/powerful a dependency for this limited use case.

For the `BitVec` stuff....

Rather than make the `Eq` function check the semantic equivalence we could spend more effort maintaining the structural equivalence of the `BitVec`.

The first thing I tried was to make toggling the LSB check the size of the vectors and resize if needed - this fixed the issue, but was bad for performance.

I tried changing how the LSB is updated when the MSB has an insert, but this caused quite a few knock on effects due to the fact that the most-significant-bit in the LSB range is truncated when it's resized. Removing this resize code had a load of knock-on issues that, to me, seemed harder to solve.

If anyone feels strongly that the `BitVec` should do it's comparisons based on the specific state and that the semantic equivalence is not good enough then we can rework this PR.