### PR TITLE
Testing features

### DIFF
--- a/crates/geo_filters/Cargo.toml
+++ b/crates/geo_filters/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 
 [features]
 default = []
+test-support = []
 serde = ["dep:serde"]
 evaluation = [
     "dep:clap",

--- a/crates/geo_filters/Cargo.toml
+++ b/crates/geo_filters/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 
 [features]
 default = []
-test-support = []
+test-support = ["dep:rand", "dep:rand_chacha"]
 serde = ["dep:serde"]
 evaluation = [
     "dep:clap",
@@ -34,6 +34,7 @@ rand = { version = "0.9", optional = true }
 rayon = { version = "1.7", optional = true }
 regex = { version = "1", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+rand_chacha = { version = "0.9", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/crates/geo_filters/Cargo.toml
+++ b/crates/geo_filters/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 
 [features]
 default = []
+serde = ["dep:serde"]
 evaluation = [
     "dep:clap",
     "dep:hyperloglogplus",
@@ -31,6 +32,7 @@ once_cell = "1.18"
 rand = { version = "0.9", optional = true }
 rayon = { version = "1.7", optional = true }
 regex = { version = "1", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/crates/geo_filters/evaluation/performance.rs
+++ b/crates/geo_filters/evaluation/performance.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo_filters::build_hasher::UnstableDefaultBuildHasher;
 use geo_filters::config::VariableConfig;
 use geo_filters::diff_count::{GeoDiffCount, GeoDiffCount13};

--- a/crates/geo_filters/src/config.rs
+++ b/crates/geo_filters/src/config.rs
@@ -353,13 +353,14 @@ pub(crate) fn take_ref<I: Iterator>(iter: &mut I, n: usize) -> impl Iterator<Ite
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use rand::{rngs::StdRng, RngCore};
+    use rand::RngCore;
+    use rand_chacha::ChaCha12Rng;
 
     use crate::{Count, Method};
 
     /// Runs estimation trials and returns the average precision and variance.
     pub(crate) fn test_estimate<M: Method, C: Count<M>>(
-        rnd: &mut StdRng,
+        rnd: &mut ChaCha12Rng,
         f: impl Fn() -> C,
     ) -> (f32, f32) {
         let cnt = 10000usize;

--- a/crates/geo_filters/src/config/lookup.rs
+++ b/crates/geo_filters/src/config/lookup.rs
@@ -45,7 +45,8 @@ impl HashToBucketLookup {
 
 #[cfg(test)]
 mod tests {
-    use rand::{rngs::StdRng, RngCore};
+    use rand::RngCore;
+    use rand_chacha::ChaCha12Rng;
 
     use crate::{
         config::{hash_to_bucket, phi_f64},
@@ -70,7 +71,7 @@ mod tests {
         });
     }
 
-    fn lookup_random_hashes_variance<const B: usize>(rnd: &mut StdRng, n: u64) -> f64 {
+    fn lookup_random_hashes_variance<const B: usize>(rnd: &mut ChaCha12Rng, n: u64) -> f64 {
         let phi = phi_f64(B);
         let buckets = HashToBucketLookup::new(B);
 

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -18,7 +18,7 @@ mod sim_hash;
 
 use bitvec::*;
 pub use config::{GeoDiffConfig13, GeoDiffConfig7};
-pub use sim_hash::SimHash;
+pub use sim_hash::{SimHash, SIM_BUCKETS, SIM_BUCKET_SIZE};
 
 /// Diff count filter with a relative error standard deviation of ~0.125.
 pub type GeoDiffCount7<'a> = GeoDiffCount<'a, GeoDiffConfig7>;

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -340,7 +340,7 @@ impl<'a, C: GeoConfig<Diff>> GeoDiffCount<'a, C> {
         Ok(bytes_written)
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn from_ones(config: C, ones: impl IntoIterator<Item = C::BucketType>) -> Self {
         let mut result = Self::new(config);
         for one in ones {
@@ -349,13 +349,13 @@ impl<'a, C: GeoConfig<Diff>> GeoDiffCount<'a, C> {
         result
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn iter_ones(&self) -> impl Iterator<Item = C::BucketType> + '_ {
         iter_ones(self.bit_chunks().peekable()).map(C::BucketType::from_usize)
     }
 
     /// Generate a pseudo-random filter. For a given number of items
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn pseudorandom_filter(config: C, items: usize) -> Self {
         use rand::RngCore;
         use rand_chacha::rand_core::SeedableRng;

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -354,7 +354,9 @@ impl<'a, C: GeoConfig<Diff>> GeoDiffCount<'a, C> {
         iter_ones(self.bit_chunks().peekable()).map(C::BucketType::from_usize)
     }
 
-    /// Generate a pseudo-random filter. For a given number of items
+    /// Generate a pseudo-random filter. The RNG used to build the filter
+    /// is seeded using the number of items so for a given number of items
+    /// the resulting geofilter should always be the same.
     #[cfg(any(test, feature = "test-support"))]
     pub fn pseudorandom_filter(config: C, items: usize) -> Self {
         use rand::RngCore;

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -338,6 +338,20 @@ impl<'a, C: GeoConfig<Diff>> GeoDiffCount<'a, C> {
         bytes_written += self.lsb.write(writer)?;
         Ok(bytes_written)
     }
+
+    #[cfg(test)]
+    pub fn from_ones(config: C, ones: impl IntoIterator<Item = C::BucketType>) -> Self {
+        let mut result = Self::new(config);
+        for one in ones {
+            result.xor_bit(one);
+        }
+        result
+    }
+
+    #[cfg(test)]
+    pub fn iter_ones(&self) -> impl Iterator<Item = C::BucketType> + '_ {
+        iter_ones(self.bit_chunks().peekable()).map(C::BucketType::from_usize)
+    }
 }
 
 /// Applies a repeated bit mask to the underlying filter.
@@ -423,7 +437,7 @@ mod tests {
 
     use crate::{
         build_hasher::UnstableDefaultBuildHasher,
-        config::{iter_ones, tests::test_estimate, FixedConfig},
+        config::{tests::test_estimate, FixedConfig},
         test_rng::prng_test_harness,
     };
 
@@ -624,20 +638,6 @@ mod tests {
         a.xor_bit(17);
         a.xor_bit(11);
         assert_eq!(vec![17, 11, 7], a.msb.iter().copied().collect_vec());
-    }
-
-    impl<C: GeoConfig<Diff>> GeoDiffCount<'_, C> {
-        fn from_ones(config: C, ones: impl IntoIterator<Item = C::BucketType>) -> Self {
-            let mut result = Self::new(config);
-            for one in ones {
-                result.xor_bit(one);
-            }
-            result
-        }
-
-        fn iter_ones(&self) -> impl Iterator<Item = C::BucketType> + '_ {
-            iter_ones(self.bit_chunks().peekable()).map(C::BucketType::from_usize)
-        }
     }
 
     #[test]

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -18,6 +18,7 @@ mod sim_hash;
 
 use bitvec::*;
 pub use config::{GeoDiffConfig13, GeoDiffConfig7};
+pub use sim_hash::SimHash;
 
 /// Diff count filter with a relative error standard deviation of ~0.125.
 pub type GeoDiffCount7<'a> = GeoDiffCount<'a, GeoDiffConfig7>;

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -21,6 +21,8 @@ pub type BucketId = usize;
 /// SimHash is a hash computed over a continuous range of bits from a GeoDiffCount.
 /// It is used to quickly find similar sets with a reverse index.
 #[derive(Copy, Clone, Default, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct SimHash(pub u64);
 
 impl SimHash {

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -12,9 +12,9 @@ use crate::Diff;
 use super::BitVec;
 
 /// Number of bits covered by each SimHash bucket.
-pub(crate) const SIM_BUCKET_SIZE: usize = 6;
+pub const SIM_BUCKET_SIZE: usize = 6;
 /// Number of consecutive SimHash buckets used for searching.
-pub(crate) const SIM_BUCKETS: usize = 20;
+pub const SIM_BUCKETS: usize = 20;
 
 pub type BucketId = usize;
 

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -11,6 +11,10 @@ use crate::Diff;
 
 use super::BitVec;
 
+// TODO migrate these const values to be defined in configuration
+// The current values are only really appropriate for smaller
+// configurations
+
 /// Number of bits covered by each SimHash bucket.
 pub const SIM_BUCKET_SIZE: usize = 6;
 /// Number of consecutive SimHash buckets used for searching.


### PR DESCRIPTION
# Motivation

There are some features we need exposed from the `geo_filters` crate to support internal usage.

# Changes

- Added or exposed various functions to help users of the library that need to test behaviours based on geofilters: `pseudorandom_filter`, `iter_ones`, `from_ones`.
- Added `serde` dependency for `SimHash`es so people who are serializing structures which use a `SimHash` can do that without wrapping out types or anything.
- Moved the deterministic test RNG to use `rand_chacha` since it is in our dependency tree now (it was before, but it wasn't being used anywhere, I suspect a copy-pasta gone awry). And this will allow test seeds to be reused across all versions of the Rust standard library.