### PR TITLE
Add rounding versions of size methods on `Count`

### DIFF
--- a/crates/geo_filters/src/config.rs
+++ b/crates/geo_filters/src/config.rs
@@ -374,7 +374,7 @@ pub(crate) mod tests {
                 m.push_hash(rnd.next_u64());
             }
             // Compute the relative error between estimate and actually inserted items.
-            let high_precision = m.size() / cnt as f32 - 1.0;
+            let high_precision = m.size_real() / cnt as f32 - 1.0;
             // Take the average over trials many attempts.
             avg_precision += high_precision / trials as f32;
             avg_var += high_precision.powf(2.0) / trials as f32;

--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -443,11 +443,11 @@ impl<C: GeoConfig<Diff>> Count<Diff> for GeoDiffCount<'_, C> {
         *self = xor(self, other);
     }
 
-    fn size(&self) -> f32 {
+    fn size_real(&self) -> f32 {
         self.estimate_size()
     }
 
-    fn size_with_sketch(&self, other: &Self) -> f32 {
+    fn size_with_sketch_real(&self, other: &Self) -> f32 {
         assert!(
             self.config == other.config,
             "combined filters must have the same configuration"
@@ -501,7 +501,7 @@ mod tests {
             let mut geo_count = GeoDiffCount13::default();
 
             (0..n).for_each(|i| geo_count.push(i));
-            assert_eq!(result, geo_count.size());
+            assert_eq!(result, geo_count.size_real());
         }
     }
 

--- a/crates/geo_filters/src/distinct_count.rs
+++ b/crates/geo_filters/src/distinct_count.rs
@@ -143,7 +143,7 @@ impl<C: GeoConfig<Distinct>> Count<Distinct> for GeoDistinctCount<'_, C> {
         *self = or(self, other)
     }
 
-    fn size(&self) -> f32 {
+    fn size_real(&self) -> f32 {
         let lowest_bucket = self.lsb.bit_range().start;
         let total = self.msb.len()
             + self
@@ -159,7 +159,7 @@ impl<C: GeoConfig<Distinct>> Count<Distinct> for GeoDistinctCount<'_, C> {
         }
     }
 
-    fn size_with_sketch(&self, other: &Self) -> f32 {
+    fn size_with_sketch_real(&self, other: &Self) -> f32 {
         assert!(
             self.config == other.config,
             "combined filters must have the same configuration"
@@ -272,7 +272,7 @@ mod tests {
         ] {
             let mut geo_count = GeoDistinctCount13::default();
             (0..n).for_each(|i| geo_count.push(i));
-            assert_eq!(result, geo_count.size());
+            assert_eq!(result, geo_count.size_real());
         }
     }
 

--- a/crates/geo_filters/src/evaluation/hll.rs
+++ b/crates/geo_filters/src/evaluation/hll.rs
@@ -126,11 +126,11 @@ impl<C: HllConfig> Count<Distinct> for Hll<C> {
         unimplemented!()
     }
 
-    fn size(&self) -> f32 {
+    fn size_real(&self) -> f32 {
         self.inner.borrow_mut().count() as f32
     }
 
-    fn size_with_sketch(&self, _other: &Self) -> f32 {
+    fn size_with_sketch_real(&self, _other: &Self) -> f32 {
         unimplemented!()
     }
 

--- a/crates/geo_filters/src/evaluation/simulation.rs
+++ b/crates/geo_filters/src/evaluation/simulation.rs
@@ -25,7 +25,7 @@ impl<C: GeoConfig<Diff> + Clone> SimulationCount for GeoDiffCount<'_, C> {
         <Self as Count<_>>::push_hash(self, hash)
     }
     fn size(&self) -> f32 {
-        <Self as Count<_>>::size(self)
+        <Self as Count<_>>::size_real(self)
     }
     fn bytes_in_memory(&self) -> usize {
         <Self as Count<_>>::bytes_in_memory(self)
@@ -36,7 +36,7 @@ impl<C: GeoConfig<Distinct>> SimulationCount for GeoDistinctCount<'_, C> {
         <Self as Count<_>>::push_hash(self, hash)
     }
     fn size(&self) -> f32 {
-        <Self as Count<_>>::size(self)
+        <Self as Count<_>>::size_real(self)
     }
     fn bytes_in_memory(&self) -> usize {
         <Self as Count<_>>::bytes_in_memory(self)
@@ -47,7 +47,7 @@ impl<C: HllConfig> SimulationCount for Hll<C> {
         <Self as Count<_>>::push_hash(self, hash)
     }
     fn size(&self) -> f32 {
-        <Self as Count<_>>::size(self)
+        <Self as Count<_>>::size_real(self)
     }
     fn bytes_in_memory(&self) -> usize {
         <Self as Count<_>>::bytes_in_memory(self)


### PR DESCRIPTION
Rename size methods to `size_real` and `size_with_sketch_real`. Add integer-returning `size` and `size_with_sketch` methods that round the floating-point estimates. Update all usages in test to call the new methods.

Added some debug assertions to panic if the math ever goes awry.