### PR TITLE
`SimHash` encapsulation

### DIFF
--- a/crates/geo_filters/src/diff_count.rs
+++ b/crates/geo_filters/src/diff_count.rs
@@ -18,7 +18,7 @@ mod sim_hash;
 
 use bitvec::*;
 pub use config::{GeoDiffConfig13, GeoDiffConfig7};
-pub use sim_hash::{SimHash, SIM_BUCKETS, SIM_BUCKET_SIZE};
+pub use sim_hash::SimHash;
 
 /// Diff count filter with a relative error standard deviation of ~0.125.
 pub type GeoDiffCount7<'a> = GeoDiffCount<'a, GeoDiffConfig7>;

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -96,7 +96,7 @@ impl<C: GeoConfig<Diff>> GeoDiffCount<'_, C> {
     /// the expected diff size.
     ///
     /// The geo_filter can be used to do an "exact" search by setting expected_diff_size to zero.
-    /// in this case, all the buckets must match. Similarly, small differences can be found by
+    /// In this case, all the buckets must match. Similarly, small differences can be found by
     /// requiring (SIM_BUCKETS - expected_diff_size) many buckets to match. For larger differences
     /// SIM_BUCKETS / 2 many buckets have to match.
     pub fn sim_hashes_search(

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -49,6 +49,11 @@ impl SimHash {
 }
 
 impl<C: GeoConfig<Diff>> GeoDiffCount<'_, C> {
+    /// TODO document, and maybe get better name
+    pub fn min_matches(&self) -> usize {
+        SIM_BUCKETS / 2
+    }
+
     /// Given the expected size of a diff, this function returns the range of bucket ids which should
     /// be searched for in order to find geometric filters of the desired similarity. If at least half
     /// of the buckets in the range match, one found a match that has the expected diff size (or better).

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -220,28 +220,3 @@ impl BitVec<'_> {
         None
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use rand::Rng as _;
-
-    use crate::{
-        diff_count::{sim_hash::SIM_BUCKETS, GeoDiffCount7},
-        test_rng::prng_test_harness,
-    };
-
-    #[test]
-    fn sim_hash_iter_min_matches() {
-        prng_test_harness(100, |rng| {
-            let i = rng.random_range(0..1000);
-            let filter = GeoDiffCount7::pseudorandom_filter(i);
-            let expected_diff = rng.random_range(0..i);
-            let (iter, min_matches) = filter.sim_hashes_search(expected_diff);
-            let actual_count = iter.count();
-            let expected_min_matches = actual_count
-                .saturating_sub(expected_diff)
-                .max(SIM_BUCKETS / 2);
-            assert_eq!(min_matches, expected_min_matches)
-        });
-    }
-}

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -104,12 +104,10 @@ impl<C: GeoConfig<Diff>> GeoDiffCount<'_, C> {
         expected_diff_size: usize,
     ) -> (impl Iterator<Item = SimHash> + '_, usize) {
         let range = self.sim_hash_range(expected_diff_size);
-        let min_matches = range
-            .len()
-            .saturating_sub(expected_diff_size)
-            .max(SIM_BUCKETS / 2);
-        let filtered_iter = self
-            .sim_hashes()
+        let sim_hash_iter = self.sim_hashes();
+        let n = range.len().min(sim_hash_iter.len());
+        let min_matches = n.saturating_sub(expected_diff_size).max(SIM_BUCKETS / 2);
+        let filtered_iter = sim_hash_iter
             .skip_while(move |(bucket_id, _)| *bucket_id >= range.end)
             .take_while(move |(bucket_id, _)| *bucket_id >= range.start)
             .map(|(_, sim_hash)| sim_hash);

--- a/crates/geo_filters/src/diff_count/sim_hash.rs
+++ b/crates/geo_filters/src/diff_count/sim_hash.rs
@@ -12,13 +12,13 @@ use crate::Diff;
 use super::BitVec;
 
 // TODO migrate these const values to be defined in configuration
-// The current values are only really appropriate for smaller
-// configurations
+// The current values are only really appropriate for the smaller
+// diff configuration.
 
 /// Number of bits covered by each SimHash bucket.
-pub const SIM_BUCKET_SIZE: usize = 6;
+const SIM_BUCKET_SIZE: usize = 6;
 /// Number of consecutive SimHash buckets used for searching.
-pub const SIM_BUCKETS: usize = 20;
+const SIM_BUCKETS: usize = 20;
 
 pub type BucketId = usize;
 


### PR DESCRIPTION
# Motivation

We previously exposed some internal details with how the sim hashes are configured in the `geo_filters` create. It would be preferable to not expose this configuration as constants (which need to have math applied to them to be useful 😄) and instead provide functions which express some more concrete usage patterns.

We needed to expose the `SIM_BUCKETS` constant so that users could calculate the number of required matches when searching for geofilters using `SimHash`es. Rather than requiring them to manually calculate this I've changed the `sim_hash_search` function to return the minimum number of matching `SimHash`es required before another filter can be considered a match.

# Implementation

Given the `SimHashIterator` always decrements its `prev_bucket_id` by 1 until it reaches zero then the initial value of this is equivalent to the length of the iterator. I've just put this into a `size_hint` and implemented `ExactSizeIterator` for `SimHashIterator`. This allows us to get the number of `SimHash`es that the iterator will produce.

Use this length or the length of the range produced by `sim_hash_range` to get the number of `SimHash`es the iterator will produce.

# Question to reviewer

Is the math such that the length of the `sim_hash_range` is _always_ shorter than the number of `SimHash`es produces by `sim_hashes` for all possible configurations of a geofilter?

