### PR TITLE
Predictable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,10 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "0 5 8-14 * 0" # Second Sunday of each month at 05:00 UTC
+      cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "0 5 8-14 * 0" # Second Sunday of each month at 05:00 UTC
+      cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC


### PR DESCRIPTION
Set dependabot to run at 05:00 UTC on the second day of the month.

Part of https://github.com/github/blackbird/issues/13090