### PR TITLE
Fix `cargo build -p geo_filters --features serde`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ test:
 	RUST_BACKTRACE=1 cargo test
 	# Amazingly, `--all-targets` causes doc-tests not to run.
 	RUST_BACKTRACE=1 cargo test --doc
+	# Check that geo_filters compiles with each feature in isolation and with no features
+	cargo check -p geo_filters --no-default-features
+	cargo check -p geo_filters --features test-support
+	cargo check -p geo_filters --features serde
+	cargo check -p geo_filters --features evaluation
 
 .PHONY: test-ignored
 test-ignored:

--- a/crates/geo_filters/Cargo.toml
+++ b/crates/geo_filters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo_filters"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Geometric filters for set cardinality estimation."
 repository = "https://github.com/github/rust-gems"
@@ -33,7 +33,7 @@ once_cell = "1.18"
 rand = { version = "0.9", optional = true }
 rayon = { version = "1.7", optional = true }
 regex = { version = "1", optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 rand_chacha = { version = "0.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This previously failed with

```
❯ cargo build -p geo_filters --features serde
   Compiling geo_filters v0.1.0 (/Users/jorendorff/src/rust-gems/crates/geo_filters)
error[E0433]: failed to resolve: could not find `Deserialize` in `serde`
   --> crates/geo_filters/src/diff_count/sim_hash.rs:28:45
    |
 28 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                             ^^^^^^^^^^^ could not find `Deserialize` in `serde`
    |
note: found an item that was configured out
   --> /Users/jorendorff/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.214/src/lib.rs:343:24
    |
341 | #[cfg(feature = "serde_derive")]
    |       ------------------------ the item is gated behind the `serde_derive` feature
342 | #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
343 | pub use serde_derive::{Deserialize, Serialize};
    |                        ^^^^^^^^^^^
```

...and two other similar errors.

It'd be nice to make a release once this merges, so I bumped the version number.