### PR TITLE
bpe-openai: use Regex::find instead of captures for pretokenization

### DIFF
--- a/crates/bpe-openai/src/lib.rs
+++ b/crates/bpe-openai/src/lib.rs
@@ -4,7 +4,6 @@ use bpe::byte_pair_encoding::BytePairEncoding;
 use either::Either;
 use regex_automata::{
     meta::{BuildError, Regex},
-    util::captures::Captures,
     Anchored, Input,
 };
 
@@ -177,7 +176,6 @@ impl Pretokenizer {
             lookahead: &self.lookahead,
             text,
             last: 0,
-            caps: Captures::matches(self.pat.group_info().clone()),
         }
     }
 }
@@ -195,7 +193,6 @@ struct Splits<'a> {
     lookahead: &'a [bool],
     text: &'a str,
     last: usize,
-    caps: Captures,
 }
 
 impl<'a> Iterator for Splits<'a> {
@@ -203,9 +200,7 @@ impl<'a> Iterator for Splits<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let input = Input::new(&self.text[self.last..]).anchored(Anchored::Yes);
-        self.caps.clear();
-        self.pat.captures(input, &mut self.caps);
-        let m = self.caps.get_match()?;
+        let m = self.pat.find(input)?;
         let start = self.last;
         let mut end = self.last + m.range().end;
         if self.lookahead[m.pattern().as_usize()] {

--- a/crates/bpe/benchmarks/performance.rs
+++ b/crates/bpe/benchmarks/performance.rs
@@ -245,8 +245,8 @@ fn worstcase_comparison_benchmark(c: &mut Criterion) {
 }
 
 fn pretokenization_benchmark(c: &mut Criterion) {
-    for (name, tokenizer, _, _) in TOKENIZERS.iter() {
-        let text = create_test_string(&tokenizer.bpe, 80_000);
+    for (name, tok, _, _) in TOKENIZERS.iter() {
+        let text = create_test_string(&tok.bpe, 80_000);
 
         let mut group = c.benchmark_group(format!("pretokenization-{name}"));
         group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
@@ -255,7 +255,7 @@ fn pretokenization_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("split", bytes), &bytes, |b, bytes| {
                 b.iter_batched(
                     || select_test_string(&text, *bytes),
-                    |text| tokenizer.split(text).count(),
+                    |text| tok.split(text).count(),
                     criterion::BatchSize::SmallInput,
                 )
             });

--- a/crates/bpe/benchmarks/performance.rs
+++ b/crates/bpe/benchmarks/performance.rs
@@ -244,12 +244,32 @@ fn worstcase_comparison_benchmark(c: &mut Criterion) {
     }
 }
 
+fn pretokenization_benchmark(c: &mut Criterion) {
+    for (name, tok, _, _) in TOKENIZERS.iter() {
+        let text = create_test_string(&tok.bpe, 80_000);
+
+        let mut group = c.benchmark_group(format!("pretokenization-{name}"));
+        group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+        for bytes in [10, 100, 1000, 10000] {
+            group.throughput(criterion::Throughput::Bytes(bytes as u64));
+            group.bench_with_input(BenchmarkId::new("split", bytes), &bytes, |b, bytes| {
+                b.iter_batched(
+                    || select_test_string(&text, *bytes),
+                    |text| tok.split(text).count(),
+                    criterion::BatchSize::SmallInput,
+                )
+            });
+        }
+        group.finish();
+    }
+}
+
 criterion_group!(
     name = benches;
     config = Criterion::default()
                 .warm_up_time(Duration::from_millis(500))
                 .measurement_time(Duration::from_millis(4000))
                 .nresamples(1000);
-    targets = counting_benchmark, encoding_benchmark, appending_benchmark, comparison_benchmark, worstcase_comparison_benchmark
+    targets = counting_benchmark, encoding_benchmark, appending_benchmark, pretokenization_benchmark, comparison_benchmark, worstcase_comparison_benchmark
 );
 criterion_main!(benches);

--- a/crates/bpe/benchmarks/performance.rs
+++ b/crates/bpe/benchmarks/performance.rs
@@ -245,8 +245,8 @@ fn worstcase_comparison_benchmark(c: &mut Criterion) {
 }
 
 fn pretokenization_benchmark(c: &mut Criterion) {
-    for (name, tok, _, _) in TOKENIZERS.iter() {
-        let text = create_test_string(&tok.bpe, 80_000);
+    for (name, tokenizer, _, _) in TOKENIZERS.iter() {
+        let text = create_test_string(&tokenizer.bpe, 80_000);
 
         let mut group = c.benchmark_group(format!("pretokenization-{name}"));
         group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
@@ -255,7 +255,7 @@ fn pretokenization_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("split", bytes), &bytes, |b, bytes| {
                 b.iter_batched(
                     || select_test_string(&text, *bytes),
-                    |text| tok.split(text).count(),
+                    |text| tokenizer.split(text).count(),
                     criterion::BatchSize::SmallInput,
                 )
             });


### PR DESCRIPTION
Replace Regex `captures` with `find` for pretokenization.

Output is identical and ran the tiktoken-equivalence tests (cl100k + o200k) on my M1 Macbook. Also I added a pretokenization-cl100k benchmark that isolates `Tokenizer::split`. Results:

 | split/ | throughput delta |
  |----------|------------|
  | 10 B | +57% |
  | 100 B | +16% |
  | 1 000 B | +11% |
  | 10 000 B | +9% |

Full `Tokenizer::encode` (comparison-cl100k) is unchanged within noise since pretokenization is a minority of encode time on that corpus.

Reasoning for the change:
The Splits iterator only needs each match's extent and pattern id but it never reads a capture group (the patterns contain none beyond the implicit whole match). It still called captures(), which clears and fills a Captures for every piece and forces a capture-reporting search. find() returns the same overall match and can use a faster DFA-based search that only reports the match start and end.