### PR TITLE
chore: add npm dependabot coverage

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,15 +6,21 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "cron"
       cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "npm"
     directory: "/crates/string-offsets/js"
     schedule:
       interval: "cron"
       cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC
+    cooldown:
+      default-days: 14

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,9 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC
+
+  - package-ecosystem: "npm"
+    directory: "/crates/string-offsets/js"
+    schedule:
+      interval: "cron"
+      cronjob: "0 5 2 * *" # Second day of each month at 05:00 UTC


### PR DESCRIPTION
## Summary
- Adds Dependabot npm coverage for `crates/string-offsets/js`
- Uses the same monthly schedule as the existing Cargo and GitHub Actions updates
- Adds a 14-day cooldown to all Dependabot update configurations

## Security alerts covered
- `js-yaml` (`crates/string-offsets/js/package-lock.json`): moderate, patched in 4.2.0 — https://github.com/github/rust-gems/security/dependabot/43, https://github.com/advisories/GHSA-h67p-54hq-rp68
- `@babel/core` (`crates/string-offsets/js/package-lock.json`): low, patched in 7.29.6 — https://github.com/github/rust-gems/security/dependabot/42, https://github.com/advisories/GHSA-4x5r-pxfx-6jf8

Generated with the update-deps skill.