### PR TITLE
docs(bpe): cite Incremental BPE Tokenization paper

### DIFF
--- a/crates/bpe/README.md
+++ b/crates/bpe/README.md
@@ -300,3 +300,6 @@ This case is particularly challenging for tiktoken, which shows a quadratic grow
 The Huggingface encoder scales better, but becomes slower and slower compared to our implementation as input size increases.
 
 ![worst-case encoding runtime comparison](./images/performance-worstcase.svg)
+
+For a full runtime analysis of incremental BPE tokenization, see Jiang and Gong, ["Incremental BPE Tokenization"](https://arxiv.org/abs/2605.30813) (ICML 2026), which presents an algorithm with a worst-case $\mathcal{O}(n \log^2 t)$ complexity (where $n$ is the input length and $t$ is the maximum token length).
+Their implementation is available at [ModelTC/mtc-inc-bpe](https://github.com/ModelTC/mtc-inc-bpe).

--- a/crates/bpe/README.md
+++ b/crates/bpe/README.md
@@ -302,4 +302,5 @@ The Huggingface encoder scales better, but becomes slower and slower compared to
 ![worst-case encoding runtime comparison](./images/performance-worstcase.svg)
 
 For a full runtime analysis of incremental BPE tokenization, see Jiang and Gong, ["Incremental BPE Tokenization"](https://arxiv.org/abs/2605.30813) (ICML 2026), which presents an algorithm with a worst-case `O(n log^2 t)` complexity (where `n` is the input length and `t` is the maximum token length).
+Their work builds on our incremental algorithm and takes it one step further by combining the aho-corasick search with the compatibility test into a single automaton.
 Their implementation is available at [ModelTC/mtc-inc-bpe](https://github.com/ModelTC/mtc-inc-bpe).

--- a/crates/bpe/README.md
+++ b/crates/bpe/README.md
@@ -301,5 +301,5 @@ The Huggingface encoder scales better, but becomes slower and slower compared to
 
 ![worst-case encoding runtime comparison](./images/performance-worstcase.svg)
 
-For a full runtime analysis of incremental BPE tokenization, see Jiang and Gong, ["Incremental BPE Tokenization"](https://arxiv.org/abs/2605.30813) (ICML 2026), which presents an algorithm with a worst-case $\mathcal{O}(n \log^2 t)$ complexity (where $n$ is the input length and $t$ is the maximum token length).
+For a full runtime analysis of incremental BPE tokenization, see Jiang and Gong, ["Incremental BPE Tokenization"](https://arxiv.org/abs/2605.30813) (ICML 2026), which presents an algorithm with a worst-case `O(n log^2 t)` complexity (where `n` is the input length and `t` is the maximum token length).
 Their implementation is available at [ModelTC/mtc-inc-bpe](https://github.com/ModelTC/mtc-inc-bpe).


### PR DESCRIPTION
## Why

The `crates/bpe` README compares our encoder against tiktoken and Huggingface tokenizers but doesn't point readers to the broader academic work on incremental BPE. Recent work provides a formal worst-case runtime analysis that's directly relevant to anyone evaluating this crate's approach.

## What

Adds a short citation at the end of the **Comparison with other tokenizers** section linking to:

- Jiang and Gong, ["Incremental BPE Tokenization"](https://arxiv.org/abs/2605.30813) (ICML 2026), which presents the full runtime analysis (worst-case `O(n log^2 t)`).
- The authors' implementation at [ModelTC/mtc-inc-bpe](https://github.com/ModelTC/mtc-inc-bpe).

Documentation-only change, no code affected.