### PR TITLE
🐛 Fix hash_bytes on big-endian and 32-bit targets

### DIFF
--- a/crates/bpe/src/byte_pair_encoding.rs
+++ b/crates/bpe/src/byte_pair_encoding.rs
@@ -1,6 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use std::ops::Range;
 
 use aneubeck_daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder};
@@ -149,7 +149,13 @@ fn token_bytes<'a>(all_tokens: &'a [u8], token_starts: &[u32], token_id: u32) ->
 
 fn hash_bytes(bytes: &[u8], factor: u64) -> u32 {
     let mut hasher = FnvHasher::default();
-    bytes.hash(&mut hasher);
+    // Write the length ourselves instead of `bytes.hash(&mut hasher)`. The slice impl
+    // prefixes it with `write_usize`, which is native-endian and pointer-sized, so the
+    // same token hashed differently on big-endian or 32-bit targets and the hardcoded
+    // hash factors stopped preventing collisions (`from_dictionary` then panics).
+    // On 64-bit little-endian this writes exactly the same bytes as before.
+    hasher.write(&(bytes.len() as u64).to_le_bytes());
+    hasher.write(bytes);
     // Note: we save 1/3 of space for the hashmap by only using the most significant bits of the hash.
     // To make them unique for the given tokens, we have to add unfortunately another multiplication.
     ((hasher.finish().wrapping_mul(factor)) >> 32) as u32
@@ -684,4 +690,26 @@ pub fn create_test_bytes(bpe: &BytePairEncoding, min_bytes: usize) -> Vec<u8> {
         result.extend(bpe.token_bytes(i as u32));
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash_bytes;
+
+    /// The hash must not depend on the target. It keys the serialized `bytes_hash_to_token`,
+    /// and a hardcoded hash factor is only collision-free for one particular mapping.
+    /// These are the values 64-bit little-endian has always produced, so a target whose
+    /// hashes drift fails here, and so does a change that would break existing users.
+    #[test]
+    fn hash_bytes_is_the_same_on_every_target() {
+        // The factor `bpe-openai` uses for cl100k_base, o200k_base and voyage3_base.
+        const FACTOR: u64 = 17846336922010275747;
+        assert_eq!(hash_bytes(b"", FACTOR), 3616665607);
+        assert_eq!(hash_bytes(b"a", FACTOR), 2433636812);
+        assert_eq!(hash_bytes(b" the", FACTOR), 1767689079);
+        assert_eq!(hash_bytes(b"hello", FACTOR), 2209557787);
+        assert_eq!(hash_bytes("🦀".as_bytes(), FACTOR), 2548432741);
+        // Tiktoken vocabularies contain arbitrary bytes, not just UTF-8.
+        assert_eq!(hash_bytes(&[0, 0xff, 0x80], FACTOR), 3276605559);
+    }
 }


### PR DESCRIPTION
## 🐛 Fix `hash_bytes` on big-endian and 32-bit targets

### The problem

`hash_bytes` hashes a token through the generic slice `Hash` impl:

```rust
bytes.hash(&mut hasher);
```

That impl prefixes the element count via `Hasher::write_length_prefix` →
`write_usize` → `write(&len.to_ne_bytes())`. `FnvHasher` doesn't override those,
so the length reaches FNV in **native byte order, at the host's pointer width**.
The same token therefore hashes to a different value on a big-endian target or a 32-bit one.

That breaks the two things that assume the mapping is fixed:

- The `hash_factor` values callers hardcode — see `bpe-openai/build.rs`, which
  passes `17846336922010275747` for `cl100k_base`, `o200k_base` and
  `voyage3_base` — were found by `find_hash_factor_for_dictionary` on a 64-bit
  little-endian machine. Once every hash changes, that factor no longer
  guarantees collision freedom, and the `assert_eq!` in `from_dictionary` fires. This breaks build on big-endian platforms.
- `bytes_hash_to_token` is a serialized field, so a dictionary serialized on one
  host can't be deserialized correctly on a host of different endianness or
  pointer width.

### The fix

Write the length explicitly, at a fixed width and a fixed byte order:

```rust
hasher.write(&(bytes.len() as u64).to_le_bytes());
hasher.write(bytes);
```

The hash is now a property of the token bytes alone.

### Compatibility

**No change on 64-bit little-endian.** The slice impl was already making exactly
these two `write` calls; the only difference is `to_ne_bytes` → `to_le_bytes` on
a value that is already 8 bytes wide. So existing hardcoded factors and already
serialized dictionaries stay valid.