### PR TITLE
Bump bpe-openai to 0.3.1

### DIFF
--- a/crates/bpe-openai/Cargo.toml
+++ b/crates/bpe-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpe-openai"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Prebuilt fast byte-pair encoders for OpenAI."
 repository = "https://github.com/github/rust-gems"


### PR DESCRIPTION
## Summary

- bump `bpe-openai` to 0.3.1 for the contributed pretokenization optimization
- publish `bpe` 0.2.2 and `bpe-openai` 0.3.1 to crates.io

## Validation

- `cargo check -p bpe-openai`
- `cargo test -p bpe-openai`
- `cargo publish -p bpe-openai --dry-run`