### PR TITLE
chore(deps): update js-yaml to 3.15.1

### DIFF
--- a/crates/string-offsets/js/package-lock.json
+++ b/crates/string-offsets/js/package-lock.json
@@ -3181,9 +3181,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Pins the development-only transitive `js-yaml` dependency from 3.14.2 to 3.15.1 so one patch closes three CPU-denial-of-service findings without a manifest or code change.

Dependency path: `jest@30.4.2 > @jest/core@30.4.2 > @jest/transform@30.4.1 > babel-plugin-istanbul@7.0.1 > @istanbuljs/load-nyc-config@1.1.0 > js-yaml@3.15.1`.

- HIGH: [`!!omap` resolution](https://github.com/github/rust-gems/security/dependabot/50) ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), tracked by [github/vuln-mgmt#230352](https://github.com/github/vuln-mgmt/issues/230352))
- HIGH: [quadratic merge-key chains](https://github.com/github/rust-gems/security/dependabot/47) ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m))
- MEDIUM: [quadratic repeated-alias merge-key handling](https://github.com/github/rust-gems/security/dependabot/44) ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), tracked by [github/vuln-mgmt#224788](https://github.com/github/vuln-mgmt/issues/224788))

This is a transitive patch update with no major-version or wide-blast-radius dependency risk. No open Dependabot PR is superseded. Generated by the `update-deps` skill.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (GPT-5.6 Sol) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>
